### PR TITLE
`PaddleOcrDetector.MaxSize` decreased from 2048 to 1536

### DIFF
--- a/docs/ocr.md
+++ b/docs/ocr.md
@@ -233,7 +233,7 @@ This allows detect any rotated texts. If your subject is 0 degree text (like sca
 
 
 ## PaddleOcrAll.Detector.MaxSize
-Default value: `2048`
+Default value: `1536`
 
 This effect the the max size of step #1, lower this value can improve performance and reduce memory usage, but will also lower the accurancy.
 


### PR DESCRIPTION
https://github.com/sdcb/PaddleSharp/commit/13b76b51d9097421bf3819e4cd37e6e2d062d251#diff-fe166047fad0e78128ef92aa38f03b583d73fe3a81cdd1057b39676de8418c9aR14
but why?

And I've noticed if providing null(so no downsampling is done) as the `MaxSize`:
https://github.com/sdcb/PaddleSharp/blob/5713096492e9a2c79412e55dd9b5cd1bdf53ca3e/src/Sdcb.PaddleOCR/PaddleOcrDetector.cs#L169-L171
`Detecor.Run()` will consume several gigabytes of memory before return.