### PR TITLE
`$ git ls-files -z | xargs -0 sed -i 's/Size.Zero/default/'`

### DIFF
--- a/build/test.linq
+++ b/build/test.linq
@@ -29,7 +29,7 @@ using PaddleOcrAll all = new(model.DetectionDirectory, model.ClassifierDirectory
 //var predictor = PaddleConfig.FromModelDir(model.DetectionDirectory);
 //predictor.Dump();
 
-using Mat scaled = src.Resize(Size.Zero, 1, 1);
+using Mat scaled = src.Resize(default, 1, 1);
 var sw = Stopwatch.StartNew();
 PaddleOcrResult result = all.Run(scaled);
 sw.ElapsedMilliseconds.Dump("elapsed");

--- a/docs/ocr.md
+++ b/docs/ocr.md
@@ -259,7 +259,7 @@ public class OcrController : Controller
         stream.CopyTo(ms);
         using Mat src = Cv2.ImDecode(ms.ToArray(), ImreadModes.Color);
         double scale = 1;
-        using Mat scaled = src.Resize(Size.Zero, scale, scale);
+        using Mat scaled = src.Resize(default, scale, scale);
 
         Stopwatch sw = Stopwatch.StartNew();
         string textResult = (await _ocr.Run(scaled)).Text;

--- a/src/Sdcb.PaddleDetection/Preprocessers/ResizeOperation.cs
+++ b/src/Sdcb.PaddleDetection/Preprocessers/ResizeOperation.cs
@@ -43,7 +43,7 @@ internal class ResizeOperation : PreprocessOperation
 			Size size = src.Size();
 			data.NetShape = new Size2f(size.Width * scale.X, size.Height * scale.Y);
 
-			Cv2.Resize(src, src, Size.Zero, scale.X, scale.Y, Interpolation);
+			Cv2.Resize(src, src, default, scale.X, scale.Y, Interpolation);
 			data.Shape = src.Size();
 			data.ScaleFactor = scale;
 		}

--- a/src/Sdcb.PaddleOCR/PaddleOcrDetector.cs
+++ b/src/Sdcb.PaddleOCR/PaddleOcrDetector.cs
@@ -257,7 +257,7 @@ public class PaddleOcrDetector : IDisposable
         double scaleRate = 1.0 * maxSize.Value / longEdge;
 
         return scaleRate < 1.0 ?
-            src.Resize(Size.Zero, scaleRate, scaleRate) :
+            src.Resize(default, scaleRate, scaleRate) :
             src.Clone();
     }
 


### PR DESCRIPTION
```
2024-01-03 19:52:05.1596|ERROR|T14|FailedImageHandler.Try|Exception for image 5892008:
System.MissingFieldException: Field not found: 'OpenCvSharp.Size.Zero'.
   at Sdcb.PaddleOCR.PaddleOcrDetector.MatResize(Mat src, Nullable`1 maxSize)
   at Sdcb.PaddleOCR.PaddleOcrDetector.RunRaw(Mat src, Size& resizedSize)
   at Sdcb.PaddleOCR.PaddleOcrDetector.Run(Mat src)
```
to compatibility with the latest [OpenCvSharp@4.9.0](https://github.com/shimat/opencvsharp/issues/1638): https://github.com/shimat/opencvsharp/pull/1613/files#diff-8a97c041dcab3a73538116b6bb1135779d1c126eb913c7301b5ec435d88c6688R20