### PR TITLE
Add PaddleSeg inference project library

### DIFF
--- a/PaddleSharp.sln
+++ b/PaddleSharp.sln
@@ -94,6 +94,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sdcb.PaddleNLP.Lac.Tests", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sdcb.PaddleNLP.Lac.Model", "src\Sdcb.PaddleNLP.Lac.Model\Sdcb.PaddleNLP.Lac.Model.csproj", "{640420BD-CE2D-4108-B82D-8B4544FC2FB0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sdcb.PaddleSeg", "src\Sdcb.PaddleSeg\Sdcb.PaddleSeg.csproj", "{5B99D3D9-BDDD-4C0A-BD51-7E24B1B69DF3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -168,6 +170,10 @@ Global
 		{640420BD-CE2D-4108-B82D-8B4544FC2FB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{640420BD-CE2D-4108-B82D-8B4544FC2FB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{640420BD-CE2D-4108-B82D-8B4544FC2FB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B99D3D9-BDDD-4C0A-BD51-7E24B1B69DF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B99D3D9-BDDD-4C0A-BD51-7E24B1B69DF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B99D3D9-BDDD-4C0A-BD51-7E24B1B69DF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B99D3D9-BDDD-4C0A-BD51-7E24B1B69DF3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -195,6 +201,7 @@ Global
 		{5756186D-613D-4656-B21D-822AB4DD9F8F} = {B3A59318-2F90-40D4-B995-7D56EB8C50F0}
 		{19222033-C5E1-4326-A597-75CF2DE4007F} = {CA2A775C-763B-4B69-AC5B-4F90DD668E4A}
 		{640420BD-CE2D-4108-B82D-8B4544FC2FB0} = {B3A59318-2F90-40D4-B995-7D56EB8C50F0}
+		{5B99D3D9-BDDD-4C0A-BD51-7E24B1B69DF3} = {B3A59318-2F90-40D4-B995-7D56EB8C50F0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {083C9A35-8781-4D12-8146-B08E4A61DA8E}

--- a/src/Sdcb.PaddleSeg/BaseModel.cs
+++ b/src/Sdcb.PaddleSeg/BaseModel.cs
@@ -1,0 +1,28 @@
+﻿using Sdcb.PaddleInference;
+
+namespace Sdcb.PaddleSeg
+{
+    public abstract class BaseModel
+    {
+        /// <summary>
+        /// Create the paddle config for the model.
+        /// </summary>
+        /// <returns>The paddle config for model.</returns>
+        public abstract PaddleConfig CreateConfig();
+
+        /// <summary>
+        /// Gets the default device for the model.
+        /// </summary>
+        public abstract Action<PaddleConfig> DefaultDevice { get; }
+
+        /// <summary>
+        /// Configure the device related config of the <see cref="PaddleConfig"/>.
+        /// </summary>
+        /// <param name="configure">The device and configure of the <see cref="PaddleConfig"/>, pass null to using model's <see cref="DefaultDevice"/>.</param>
+        /// <param name="config">The PaddleConfig to modify.</param>
+        public virtual void ConfigureDevice(PaddleConfig config, Action<PaddleConfig>? configure = null)
+        {
+            config.Apply(configure ?? DefaultDevice);
+        }
+    }
+}

--- a/src/Sdcb.PaddleSeg/FileSegModel.cs
+++ b/src/Sdcb.PaddleSeg/FileSegModel.cs
@@ -1,0 +1,28 @@
+﻿using Sdcb.PaddleInference;
+
+namespace Sdcb.PaddleSeg
+{
+    public class FileSegModel : SegModel
+    {
+        /// <summary>
+        /// Gets the directory path containing the model files.
+        /// </summary>
+        public string DirectoryPath { get; init; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileDetectionModel"/> class with the specified directory path.
+        /// </summary>
+        /// <param name="directoryPath">The directory path containing the model files.</param>
+        /// <param name="version">The version of detection model.</param>
+        public FileSegModel(string directoryPath)
+        {
+            DirectoryPath = directoryPath;
+        }
+
+        /// <summary>
+        /// Creates a PaddleConfig object using the model directory path.
+        /// </summary>
+        /// <returns>A <see cref="PaddleConfig"/> object created using <see cref="DirectoryPath"/>.</returns>
+        public override PaddleConfig CreateConfig() => PaddleConfig.FromModelDir(DirectoryPath);
+    }
+}

--- a/src/Sdcb.PaddleSeg/PaddleSegPredictor.cs
+++ b/src/Sdcb.PaddleSeg/PaddleSegPredictor.cs
@@ -1,0 +1,120 @@
+﻿using System.Runtime.InteropServices;
+using OpenCvSharp;
+using Sdcb.PaddleInference;
+
+namespace Sdcb.PaddleSeg
+{
+    /// <summary>
+    /// Handles image segmentation prediction using PaddlePaddle inference
+    /// </summary>
+    internal class PaddleSegPredictor : IDisposable
+    {
+        private readonly PaddlePredictor _p;
+
+        /// <summary>
+        /// Initializes a new instance of PaddleSegPredictor
+        /// </summary>
+        /// <param name="model">The segmentation model to use</param>
+        /// <param name="configure">Optional configuration action for PaddleConfig</param>
+        public PaddleSegPredictor(SegModel model, Action<PaddleConfig>? configure = null)
+        {
+            PaddleConfig c = model.CreateConfig();
+            model.ConfigureDevice(c, configure);
+
+            _p = c.CreatePredictor();
+        }
+
+        /// <summary>
+        /// Performs segmentation on the input image
+        /// </summary>
+        /// <param name="img">Input image in BGR format</param>
+        /// <returns>Array of segmentation labels where each element represents the class ID for a pixel</returns>
+        public int[] Run(Mat img)
+        {
+            // Convert BGR to RGB color space
+            Cv2.CvtColor(img, img, ColorConversionCodes.BGR2RGB);
+            
+            // Normalize the image
+            Mat mat = Normalize(img);
+            
+            using PaddlePredictor predictor = _p.Clone();
+            using (PaddleTensor input = predictor.GetInputTensor(predictor.InputNames[0]))
+            {
+                // Set input shape: [batch_size=1, channels=3, height, width]
+                input.Shape = new[] { 1, 3, mat.Rows, mat.Cols };
+                float[] data = ExtractMat(mat);
+                input.SetData(data);
+            }
+            
+            if (!predictor.Run())
+            {
+                throw new Exception("PaddlePredictor(Detector) run failed.");
+            }
+            
+            using (PaddleTensor output = predictor.GetOutputTensor(predictor.OutputNames[0]))
+            {
+                int[] data = output.GetData<int>();
+                int[] shape = output.Shape;
+                return data;
+            }
+        }
+
+        /// <summary>
+        /// Normalizes the input image by:
+        /// 1. Converting to float32 and scaling to [0,1]
+        /// 2. Applying formula: (x - 0.5) / 0.5
+        /// </summary>
+        /// <param name="src">Source image</param>
+        /// <returns>Normalized image</returns>
+        private static Mat Normalize(Mat src)
+        {
+            Mat imFloat = new Mat();
+            src.ConvertTo(imFloat, MatType.CV_32FC3, 1.0 / 255.0);
+
+            imFloat = (imFloat - 0.5) / 0.5;
+
+            return imFloat;
+        }
+
+        /// <summary>
+        /// Extracts image data into a float array in CHW (Channel, Height, Width) format
+        /// required by PaddlePaddle
+        /// </summary>
+        /// <param name="src">Source image with 3 channels</param>
+        /// <returns>Float array containing image data in CHW format</returns>
+        private static float[] ExtractMat(Mat src)
+        {
+            int rows = src.Rows;
+            int cols = src.Cols;
+            float[] result = new float[rows * cols * 3];
+            GCHandle resultHandle = default;
+            try
+            {
+                resultHandle = GCHandle.Alloc(result, GCHandleType.Pinned);
+                IntPtr resultPtr = resultHandle.AddrOfPinnedObject();
+                
+                // Extract each channel and store in CHW format
+                for (int i = 0; i < src.Channels(); ++i)
+                {
+                    // Convert BGR to RGB order
+                    int rgb = 2 - i;
+                    using Mat dest = new(rows, cols, MatType.CV_32FC1, resultPtr + i * rows * cols * sizeof(float));
+                    Cv2.ExtractChannel(src, dest, rgb);
+                }
+            }
+            finally
+            {
+                resultHandle.Free();
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Disposes the underlying PaddlePredictor
+        /// </summary>
+        public void Dispose()
+        {
+            _p.Dispose();
+        }
+    }
+}

--- a/src/Sdcb.PaddleSeg/Sdcb.PaddleSeg.csproj
+++ b/src/Sdcb.PaddleSeg/Sdcb.PaddleSeg.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="OpenCvSharp4" Version="4.9.0.20240103" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Sdcb.PaddleInference\Sdcb.PaddleInference.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Sdcb.PaddleSeg/SegModel.cs
+++ b/src/Sdcb.PaddleSeg/SegModel.cs
@@ -1,0 +1,11 @@
+﻿using Sdcb.PaddleInference;
+
+namespace Sdcb.PaddleSeg
+{
+    public abstract class SegModel : BaseModel
+    {
+        public static SegModel FromDirectory(string directoryPath) => new FileSegModel(directoryPath);
+
+        public override Action<PaddleConfig> DefaultDevice => PaddleDevice.Mkldnn();
+    }
+}

--- a/src/Sdcb.PaddleSeg/paddleseg.md
+++ b/src/Sdcb.PaddleSeg/paddleseg.md
@@ -1,0 +1,79 @@
+# Sdcb.PaddleSeg Usage Example
+
+This example demonstrates how to use Sdcb.PaddleSeg for image segmentation.
+
+## Basic Usage
+
+### 1. Import Required Namespaces
+
+```csharp
+using OpenCvSharp;
+using Sdcb.PaddleInference;
+using Sdcb.PaddleSeg;
+```
+
+### 2. Load Model
+
+First, load the segmentation model from the model directory:
+
+```csharp
+SegModel segModel = SegModel.FromDirectory(@"E:\gitproject\PaddleSeg\output\infer_model");
+```
+
+### 3. Create Predictor
+
+Create a predictor using the loaded model, here we use MKLDNN acceleration:
+
+```csharp
+PaddleSegPredictor paddleSegPredictor = new PaddleSegPredictor(segModel, PaddleDevice.Mkldnn());
+```
+
+### 4. Load Image and Perform Prediction
+
+```csharp
+// Load input image
+Mat img = new Mat(@"E:\gitproject\PaddleSeg\datasets\optic_disc_seg\JPEGImages\H0002.jpg");
+
+// Perform prediction
+var result = paddleSegPredictor.Run(img);
+```
+
+### 5. Process Prediction Results
+
+Convert the prediction results to a binary mask image:
+
+```csharp
+// Create single-channel mask image
+Mat mask = new Mat(img.Size(), MatType.CV_8UC1);
+
+// Convert segmentation result to mask
+int width = img.Width;
+int height = img.Height;
+for (int y = 0; y < height; y++)
+{
+    for (int x = 0; x < width; x++)
+    {
+        int index = y * width + x;
+        if (index < result.Length)
+        {
+            // Convert 1 to 255, keep 0 as 0
+            mask.Set(y, x, result[index] == 1 ? (byte)255 : (byte)0);
+        }
+    }
+}
+
+// Save mask image
+Cv2.ImWrite("mask.png", mask);
+```
+
+## Notes
+
+1. Ensure that `Sdcb.PaddleSeg`, `Sdcb.PaddleInference`, and `OpenCvSharp4` NuGet packages are properly installed
+2. Model path should point to a valid PaddleSeg exported model directory
+3. Input image path should be a valid image file path
+
+## Results
+
+The program will generate a binary mask image named `mask.png`, where:
+- White regions (255) represent the target area
+- Black regions (0) represent the background


### PR DESCRIPTION
Added the PaddleSeg inference library and successfully performed inference using the PP-LiteSeg model.

The inference image is as follows
![H0002](https://github.com/user-attachments/assets/6e4fdd6d-9de8-4220-af97-735851143829)

The resulting image is as follows
![mask](https://github.com/user-attachments/assets/2f024380-d101-4436-939d-0aa0ee9d95f5)

Official Python inference results are as follow
![H0002](https://github.com/user-attachments/assets/91fe0e45-721d-4827-a3ef-b9bae29ff3ac)
![H0002](https://github.com/user-attachments/assets/dd522af4-96a3-4851-855c-c812572922c1)
