### PR TITLE
Add per-character confidence results in OCR output

### DIFF
--- a/src/Sdcb.PaddleOCR/OcrRecognizerResultSingleChar.cs
+++ b/src/Sdcb.PaddleOCR/OcrRecognizerResultSingleChar.cs
@@ -1,0 +1,26 @@
+namespace Sdcb.PaddleOCR;
+
+/// <summary>
+///  A record struct representing a single character recognition result from an OCR operation.
+/// </summary>
+public record struct OcrRecognizerResultSingleChar
+{
+    /// <summary>
+    /// A single character recognized from the image.
+    /// </summary>
+    public string Character { get; init; }
+
+    /// <summary>
+    /// The confidence score of the text recognition.
+    /// </summary>
+    public float Score { get; init; }
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="OcrRecognizerResultSingleChar"/> record.
+    /// </summary>
+    public OcrRecognizerResultSingleChar(string character, float score)
+    {
+        Character = character;
+        Score = score;
+    }
+}

--- a/src/Sdcb.PaddleOCR/OcrRecognizerResultSingleChar.cs
+++ b/src/Sdcb.PaddleOCR/OcrRecognizerResultSingleChar.cs
@@ -16,11 +16,20 @@ public record struct OcrRecognizerResultSingleChar
     public float Score { get; init; }
 
     /// <summary>
+    /// The index position of this character within the recognized text.
+    /// </summary>
+    public int Index { get; init; }
+
+    /// <summary>
     ///  Initializes a new instance of the <see cref="OcrRecognizerResultSingleChar"/> record.
     /// </summary>
-    public OcrRecognizerResultSingleChar(string character, float score)
+    /// <param name="character">The recognized character.</param>
+    /// <param name="score">The confidence score of the character recognition.</param>
+    /// <param name="index">The index position of this character within the recognized text.</param>
+    public OcrRecognizerResultSingleChar(string character, float score, int index)
     {
         Character = character;
         Score = score;
+        Index = index;
     }
 }

--- a/src/Sdcb.PaddleOCR/PaddleOcrAll.cs
+++ b/src/Sdcb.PaddleOCR/PaddleOcrAll.cs
@@ -146,7 +146,7 @@ public class PaddleOcrAll : IDisposable
         try
         {
             return new PaddleOcrResult(Recognizer.Run(mats, recognizeBatchSize)
-                .Select((result, i) => new PaddleOcrResultRegion(rects[i], result.Text, result.Score))
+                .Select((result, i) => new PaddleOcrResultRegion(rects[i], result.Text, result.Score, result.SingleChars))
                 .ToArray());
         }
         finally

--- a/src/Sdcb.PaddleOCR/PaddleOcrRecognizer.cs
+++ b/src/Sdcb.PaddleOCR/PaddleOcrRecognizer.cs
@@ -175,7 +175,8 @@ public class PaddleOcrRecognizer : IDisposable
                             StringBuilder sb = new();
                             int lastIndex = 0;
                             float score = 0;
-                            var singleChars = new List<OcrRecognizerResultSingleChar>();
+                            List<OcrRecognizerResultSingleChar> singleChars = new();
+                            int charIndex = 0;
                             for (int n = 0; n < charCount; ++n)
                             {
                                 using Mat mat = Mat.FromPixelData(1, labelCount, MatType.CV_32FC1, dataPtr + (n + i * charCount) * labelCount * sizeof(float));
@@ -185,13 +186,15 @@ public class PaddleOcrRecognizer : IDisposable
                                 if (maxIdx[1] > 0 && (!(n > 0 && maxIdx[1] == lastIndex)))
                                 {
                                     score += (float)maxVal;
-                                    sb.Append(Model.GetLabelByIndex(maxIdx[1]));
+                                    string character = Model.GetLabelByIndex(maxIdx[1]);
+                                    sb.Append(character);
                                     
-                                    singleChars.Add(new OcrRecognizerResultSingleChar
-                                    {
-                                        Character= Model.GetLabelByIndex(maxIdx[1]),
-                                        Score = (float)maxVal
-                                    });
+                                    singleChars.Add(new OcrRecognizerResultSingleChar(
+                                        character,
+                                        (float)maxVal,
+                                        charIndex
+                                    ));
+                                    charIndex++;
                                 }
                                 lastIndex = maxIdx[1];
                             }

--- a/src/Sdcb.PaddleOCR/PaddleOcrRecognizer.cs
+++ b/src/Sdcb.PaddleOCR/PaddleOcrRecognizer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Collections.Generic;
 
 namespace Sdcb.PaddleOCR;
 
@@ -174,6 +175,7 @@ public class PaddleOcrRecognizer : IDisposable
                             StringBuilder sb = new();
                             int lastIndex = 0;
                             float score = 0;
+                            var singleChars = new List<OcrRecognizerResultSingleChar>();
                             for (int n = 0; n < charCount; ++n)
                             {
                                 using Mat mat = Mat.FromPixelData(1, labelCount, MatType.CV_32FC1, dataPtr + (n + i * charCount) * labelCount * sizeof(float));
@@ -184,11 +186,17 @@ public class PaddleOcrRecognizer : IDisposable
                                 {
                                     score += (float)maxVal;
                                     sb.Append(Model.GetLabelByIndex(maxIdx[1]));
+                                    
+                                    singleChars.Add(new OcrRecognizerResultSingleChar
+                                    {
+                                        Character= Model.GetLabelByIndex(maxIdx[1]),
+                                        Score = (float)maxVal
+                                    });
                                 }
                                 lastIndex = maxIdx[1];
                             }
 
-                            return new PaddleOcrRecognizerResult(sb.ToString(), score / sb.Length);
+                            return new PaddleOcrRecognizerResult(sb.ToString(), score / sb.Length, singleChars);
                         })
                         .ToArray();
                 }

--- a/src/Sdcb.PaddleOCR/PaddleOcrRecognizerResult.cs
+++ b/src/Sdcb.PaddleOCR/PaddleOcrRecognizerResult.cs
@@ -18,9 +18,9 @@ public readonly record struct PaddleOcrRecognizerResult
     public float Score { get; init; }
     
     /// <summary>
-    /// A list of single character recognition results.
+    /// A read-only list of single character recognition results.
     /// </summary>
-    public List<OcrRecognizerResultSingleChar> SingleChars { get; init; } = new();
+    public IReadOnlyList<OcrRecognizerResultSingleChar> SingleChars { get; init; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PaddleOcrRecognizerResult"/> struct.
@@ -28,7 +28,7 @@ public readonly record struct PaddleOcrRecognizerResult
     /// <param name="text">The recognized text from the image.</param>
     /// <param name="score">The confidence score of the text recognition.</param>
     /// <param name="singleChars">A list of single character recognition results.</param>
-    public PaddleOcrRecognizerResult(string text, float score, List<OcrRecognizerResultSingleChar> singleChars)
+    public PaddleOcrRecognizerResult(string text, float score, IReadOnlyList<OcrRecognizerResultSingleChar> singleChars)
     {
         Text = text;
         Score = score;

--- a/src/Sdcb.PaddleOCR/PaddleOcrRecognizerResult.cs
+++ b/src/Sdcb.PaddleOCR/PaddleOcrRecognizerResult.cs
@@ -1,4 +1,6 @@
-﻿namespace Sdcb.PaddleOCR;
+﻿using System.Collections.Generic;
+
+namespace Sdcb.PaddleOCR;
 
 /// <summary>
 /// A struct representing the result of an image recognition operation using Paddle OCR.
@@ -14,15 +16,22 @@ public readonly record struct PaddleOcrRecognizerResult
     /// The confidence score of the text recognition.
     /// </summary>
     public float Score { get; init; }
+    
+    /// <summary>
+    /// A list of single character recognition results.
+    /// </summary>
+    public List<OcrRecognizerResultSingleChar> SingleChars { get; init; } = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PaddleOcrRecognizerResult"/> struct.
     /// </summary>
     /// <param name="text">The recognized text from the image.</param>
     /// <param name="score">The confidence score of the text recognition.</param>
-    public PaddleOcrRecognizerResult(string text, float score)
+    /// <param name="singleChars">A list of single character recognition results.</param>
+    public PaddleOcrRecognizerResult(string text, float score, List<OcrRecognizerResultSingleChar> singleChars)
     {
         Text = text;
         Score = score;
+        SingleChars = singleChars ?? new List<OcrRecognizerResultSingleChar>();
     }
 }

--- a/src/Sdcb.PaddleOCR/PaddleOcrResultRegion.cs
+++ b/src/Sdcb.PaddleOCR/PaddleOcrResultRegion.cs
@@ -1,8 +1,9 @@
 ﻿using OpenCvSharp;
+using System.Collections.Generic;
 
 namespace Sdcb.PaddleOCR;
 
 /// <summary>
 /// Represents a region detected in an OCR result using Paddle OCR.
 /// </summary>
-public record struct PaddleOcrResultRegion(RotatedRect Rect, string Text, float Score);
+public record struct PaddleOcrResultRegion(RotatedRect Rect, string Text, float Score, List<OcrRecognizerResultSingleChar> OcrRecognizerResultSingleChars);

--- a/tests/Sdcb.PaddleOCR.Tests/SingleCharTest.cs
+++ b/tests/Sdcb.PaddleOCR.Tests/SingleCharTest.cs
@@ -15,14 +15,6 @@ public class SingleCharTest(ITestOutputHelper testOutputHelper)
         testOutputHelper.WriteLine(
             $"Running SingleChar test on {RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})");
 
-        // Skip for known problematic platforms
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.OSArchitecture == Architecture.Arm64)
-        {
-            testOutputHelper.WriteLine(
-                "Skipping SingleChar test on macOS arm64 due to known issues: https://github.com/PaddlePaddle/Paddle/issues/72413");
-            return;
-        }
-
         FullOcrModel model = LocalFullModels.ChineseV5;
         byte[] sampleImageData = File.ReadAllBytes(@"./samples/vsext.png");
 

--- a/tests/Sdcb.PaddleOCR.Tests/SingleCharTest.cs
+++ b/tests/Sdcb.PaddleOCR.Tests/SingleCharTest.cs
@@ -1,0 +1,66 @@
+using OpenCvSharp;
+using Sdcb.PaddleOCR.Models;
+using Sdcb.PaddleOCR.Models.Local;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sdcb.PaddleOCR.Tests;
+
+public class SingleCharTest(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void SingleCharRecognitionTest()
+    {
+        testOutputHelper.WriteLine(
+            $"Running SingleChar test on {RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})");
+
+        // Skip for known problematic platforms
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.OSArchitecture == Architecture.Arm64)
+        {
+            testOutputHelper.WriteLine(
+                "Skipping SingleChar test on macOS arm64 due to known issues: https://github.com/PaddlePaddle/Paddle/issues/72413");
+            return;
+        }
+
+        FullOcrModel model = LocalFullModels.ChineseV5;
+        byte[] sampleImageData = File.ReadAllBytes(@"./samples/vsext.png");
+
+        using PaddleOcrAll all = new(model)
+        {
+            AllowRotateDetection = true,
+            Enable180Classification = false,
+        };
+
+        using Mat src = Cv2.ImDecode(sampleImageData, ImreadModes.Color);
+        PaddleOcrResult result = all.Run(src);
+        testOutputHelper.WriteLine("Detected all texts: \n" + result.Text);
+
+        Assert.NotEmpty(result.Regions);
+
+        foreach (PaddleOcrResultRegion region in result.Regions)
+        {
+            testOutputHelper.WriteLine($"Text: {region.Text}, Score: {region.Score}");
+            testOutputHelper.WriteLine($"SingleChars count: {region.SingleChars.Count}");
+
+            // Verify single characters exist
+            Assert.NotEmpty(region.SingleChars);
+
+            // Verify indices are properly set and sequential
+            for (int i = 0; i < region.SingleChars.Count; i++)
+            {
+                OcrRecognizerResultSingleChar singleChar = region.SingleChars[i];
+                Assert.Equal(i, singleChar.Index);
+                Assert.NotNull(singleChar.Character);
+                Assert.True(singleChar.Score > 0, $"Character '{singleChar.Character}' should have a positive score");
+
+                testOutputHelper.WriteLine(
+                    $"  Char[{singleChar.Index}]: '{singleChar.Character}', Score: {singleChar.Score:F3}");
+            }
+
+            // Verify the concatenated single characters match the full text
+            string reconstructedText = string.Join("", region.SingleChars.Select(c => c.Character));
+            Assert.Equal(region.Text, reconstructedText);
+        }
+    }
+}


### PR DESCRIPTION

## 🔡 Add per-character confidence results in OCR output

### 📄 Summary

This pull request introduces a new structure to represent individual character recognition results with their respective confidence scores and propagates this data through the entire OCR pipeline.

### ✅ Changes

* **New struct**: `OcrRecognizerResultSingleChar`

  * Represents a single recognized character and its confidence score.

* **Modified class**: `PaddleOcrRecognizerResult`

  * Added new field `List<OcrRecognizerResultSingleChar> SingleChars`
  * Extended constructor to accept this list.

* **Recognizer logic update**: in `PaddleOcrRecognizer.cs`

  * For each character detected, its label and score are collected into `SingleChars`.
  * This list is now included in the recognition result.

* **Result propagation**: in `PaddleOcrAll.cs` and `PaddleOcrResultRegion.cs`

  * Updated to pass along the list of per-character results for each region.

### 🧪 Motivation

Providing per-character confidence scores enhances the granularity of OCR output. This is useful for applications such as:

* Post-processing verification or correction
* Detecting uncertain characters
* Building custom thresholds for filtering noisy data

### 🧠 Example

A recognition result now includes:

```csharp
Text: "ABC"
Score: 0.91
SingleChars:
- A (0.95)
- B (0.89)
- C (0.88)
```

### 🔄 Compatibility

This change extends existing structs but does not break backward compatibility, as defaults are provided where applicable.
