### PR TITLE
Fix: Update PaddleOcrResultRegion to Use IReadOnlyList (Missed in Previous PR)

### DIFF
--- a/src/Sdcb.PaddleOCR/PaddleOcrResultRegion.cs
+++ b/src/Sdcb.PaddleOCR/PaddleOcrResultRegion.cs
@@ -6,4 +6,4 @@ namespace Sdcb.PaddleOCR;
 /// <summary>
 /// Represents a region detected in an OCR result using Paddle OCR.
 /// </summary>
-public record struct PaddleOcrResultRegion(RotatedRect Rect, string Text, float Score, List<OcrRecognizerResultSingleChar> OcrRecognizerResultSingleChars);
+public record struct PaddleOcrResultRegion(RotatedRect Rect, string Text, float Score, IReadOnlyList<OcrRecognizerResultSingleChar> OcrRecognizerResultSingleChars);


### PR DESCRIPTION
### 🔧 Fix: Update `PaddleOcrResultRegion` to Use `IReadOnlyList` (Missed in Previous PR)

#### Context

This change corrects a missed update from the previous pull request where `PaddleOcrResultRegion` was meant to use `IReadOnlyList<OcrRecognizerResultSingleChar>` instead of `List<OcrRecognizerResultSingleChar>`. The prior PR was merged, but the code fails to compile due to the mismatch between the definition and usage.

#### What’s Fixed

Replaces the `List` type with `IReadOnlyList` in the record struct:

```csharp
/// <summary>
/// Represents a region detected in an OCR result using Paddle OCR.
/// </summary>
public record struct PaddleOcrResultRegion(
    RotatedRect Rect,
    string Text,
    float Score,
    IReadOnlyList<OcrRecognizerResultSingleChar> OcrRecognizerResultSingleChars);
```
#### Additional Notes

* This is a minimal patch — no logic changes, just the type correction.
